### PR TITLE
fix: camera link filter and error handling

### DIFF
--- a/custom_components/meraki_ha/web_api.py
+++ b/custom_components/meraki_ha/web_api.py
@@ -492,14 +492,23 @@ async def handle_get_available_cameras(
 
         # If integration filter is set, check if entity belongs to that integration
         if integration_filter:
+            # Normalize filter for flexible matching (blue_iris matches blueiris)
+            normalized_filter = integration_filter.replace("_", "").replace("-", "")
             entity_entry = entity_registry.async_get(entity_id)
             if entity_entry:
                 # Check platform (integration domain)
-                if integration_filter not in entity_entry.platform.lower():
+                platform = entity_entry.platform.lower()
+                normalized_platform = platform.replace("_", "").replace("-", "")
+                filter_matches = (
+                    normalized_filter in normalized_platform
+                    or normalized_platform in normalized_filter
+                )
+                if not filter_matches:
                     continue
             else:
                 # No registry entry, try to match by entity_id pattern
-                if integration_filter not in entity_id.lower():
+                normalized_entity = entity_id.lower().replace("_", "").replace("-", "")
+                if normalized_filter not in normalized_entity:
                     continue
 
         friendly_name = state.attributes.get("friendly_name", entity_id)


### PR DESCRIPTION
## Fixes

### Camera Link Filter Not Matching
- Integration filter values like `blue_iris` now match platforms like `blueiris`
- Normalizes both filter and platform names by removing underscores and hyphens
- Checks both directions: `filter in platform` OR `platform in filter`

### Camera Image 500 Errors  
- Added try-except around entire `async_camera_image` method
- Returns cached snapshot on any failure instead of throwing exception
- Prevents HA camera proxy from returning 500 Internal Server Error

### Testing
After merge, the camera link dropdown should show cameras even when an integration filter is set, and camera images should display without 500 errors.