### PR TITLE
fix: add --target to release create and improve HACS install

### DIFF
--- a/.github/workflows/beta-version-update.yaml
+++ b/.github/workflows/beta-version-update.yaml
@@ -110,12 +110,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Fresh checkout ensures we're on the commit with the version bump
+          # --target beta is REQUIRED to ensure the release is created from
+          # the just-pushed commit, not from GitHub's cached branch state
           gh release create "v${{ needs.version.outputs.new_version }}" \
             --repo "${{ github.repository }}" \
             --title "v${{ needs.version.outputs.new_version }}" \
             --generate-notes \
-            --prerelease
+            --prerelease \
+            --target beta
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/production-version-update.yaml
+++ b/.github/workflows/production-version-update.yaml
@@ -105,11 +105,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Fresh checkout ensures we're on the commit with the version bump
+          # --target main is REQUIRED to ensure the release is created from
+          # the just-pushed commit, not from GitHub's cached branch state
           gh release create "v${{ needs.version.outputs.new_version }}" \
             --repo "${{ github.repository }}" \
             --title "Release v${{ needs.version.outputs.new_version }}" \
-            --generate-notes
+            --generate-notes \
+            --target main
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Critical Fixes

### Release Tag Pointing to Wrong Commit
The `gh release create` command was missing `--target beta`.

Without this flag, GitHub uses its cached branch state, which may not include the just-pushed version bump commit. This is why releases were still pointing to old commits with version 8 in the manifest.

**Fix**: Added `--target beta` (and `--target main` for production) to force the release to be created from the latest commit.

### HACS Install Service
Changed from `hacs/repository` service (which returns 400) to the standard HA `update/install` service:
- Uses entity_id and version parameters
- Tries both with and without 'v' prefix
- Better error logging

### Also Fixed beta.14
Manually deleted and recreated v2.2.1-beta.14 from the correct commit. It now has version 2.2.1-beta.14 in the manifest.