### PR TITLE
fix: Update screenshot mock to support WebSocket subscription

### DIFF
--- a/scripts/generate_screenshots.py
+++ b/scripts/generate_screenshots.py
@@ -405,14 +405,28 @@ def create_screenshot_html() -> str:
         customElements.whenDefined('meraki-panel').then(() => {{
             const panel = document.getElementById('panel');
 
-            // Create a mock hass object
+            // Mock data for the panel
+            const mockData = {mock_data_json};
+
+            // Create a mock hass object with connection for WebSocket subscription
             const mockHass = {{
                 callWS: async (params) => {{
                     console.log('Mock callWS called with:', params);
                     if (params.type === 'meraki_ha/get_config') {{
-                        return {mock_data_json};
+                        return mockData;
                     }}
                     return {{}};
+                }},
+                connection: {{
+                    subscribeMessage: async (callback, params) => {{
+                        console.log('Mock subscribeMessage called with:', params);
+                        if (params.type === 'meraki_ha/subscribe_meraki_data') {{
+                            // Immediately call callback with mock data (simulates initial data)
+                            setTimeout(() => callback(mockData), 100);
+                        }}
+                        // Return unsubscribe function
+                        return () => {{}};
+                    }},
                 }},
                 states: {{}},
                 services: {{}},


### PR DESCRIPTION
## Summary

Fix screenshot generation workflow after switching to WebSocket subscription API.

## Changes

- Add `connection.subscribeMessage` to mock hass object in screenshot generator
- Mock returns data via callback to simulate real subscription behavior

## Context

This fixes the CI failure where the screenshot script couldn't click the Settings button because the panel wasn't loading data (the mock didn't support the new subscription API).