### PR TITLE
Config flow load error

### DIFF
--- a/custom_components/meraki_ha/config_flow.py
+++ b/custom_components/meraki_ha/config_flow.py
@@ -97,8 +97,13 @@ class MerakiConfigFlow(ConfigFlow, domain="meraki_ha"):  # type: ignore[call-arg
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
-        """Get the options flow for this handler."""
-        return MerakiOptionsFlowHandler(config_entry)
+        """Get the options flow for this handler.
+
+        Note: As of Home Assistant 2025.x, we should NOT pass config_entry
+        to the OptionsFlow constructor. The framework sets up config_entry
+        after initialization via the handler property.
+        """
+        return MerakiOptionsFlowHandler()
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

`[patch] Fix: Options flow returns 500 error due to HA 2025.x OptionsFlow pattern`

## Description

Updated `MerakiOptionsFlowHandler` to align with Home Assistant 2025.x `OptionsFlow` lifecycle. The `config_entry` is now lazily loaded via a property in async steps, instead of being passed to the constructor. This resolves a `RuntimeError: Frame helper not set up` that caused a 500 error when loading the options flow.

## Motivation and Context

This PR addresses #91, a regression where the options flow failed to load. The issue stemmed from an outdated pattern for handling `config_entry` in `OptionsFlow` that is no longer compatible with Home Assistant 2025.x, triggering a deprecated setter and a runtime error.

## How Has This Been Tested?

- All 791 existing unit tests pass.
- New tests were added in `test_options_flow.py` to specifically cover the updated `OptionsFlow` initialization and lazy loading behavior, including a test simulating the full Home Assistant setup of the options flow.
- All quality checks (`./run_checks.sh` - ruff, bandit, mypy, pytest) pass.

## Screenshots (if appropriate)

N/A

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

---
<a href="https://cursor.com/background-agent?bcId=bc-8fa37a33-0804-49a5-af7e-897ed8e41e55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8fa37a33-0804-49a5-af7e-897ed8e41e55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

