### PR TITLE
Missing options translations

### DIFF
--- a/custom_components/meraki_ha/options_flow.py
+++ b/custom_components/meraki_ha/options_flow.py
@@ -521,66 +521,68 @@ class MerakiOptionsFlowHandler(OptionsFlow):
             new_schema_keys[key] = value
         return vol.Schema(new_schema_keys)
 
-
-async def async_step_webhooks(
-    self,
-    user_input: dict[str, Any] | None = None,
-) -> ConfigFlowResult:
-    """Handle webhook settings."""
-    from .const import (
-        CONF_WEBHOOK_EXTERNAL_URL,
-        DEFAULT_WEBHOOK_EXTERNAL_URL,
-    )
-    from .core.errors import MerakiConnectionError
-    from .webhook import get_webhook_url
-
-    if user_input is not None:
-        self.options.update(user_input)
-        return self.async_create_entry(title=CONF_INTEGRATION_TITLE, data=self.options)
-
-    custom_url = self.options.get(
-        CONF_WEBHOOK_EXTERNAL_URL, DEFAULT_WEBHOOK_EXTERNAL_URL
-    )
-
-    try:
-        webhook_url = get_webhook_url(
-            self.hass, self.config_entry.entry_id, custom_url or None
+    async def async_step_webhooks(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Handle webhook settings."""
+        from .const import (
+            CONF_WEBHOOK_EXTERNAL_URL,
+            DEFAULT_WEBHOOK_EXTERNAL_URL,
         )
-        status = "✅ Webhooks active and receiving data"  # Placeholder
-    except MerakiConnectionError as err:
-        webhook_url = f"⚠️ {err}"
-        status = "❌ Webhook URL not reachable"
+        from .core.errors import MerakiConnectionError
+        from .webhook import get_webhook_url
 
-    schema_with_defaults = self._populate_schema_defaults(
-        SCHEMA_WEBHOOKS,
-        self.options,
-    )
+        if user_input is not None:
+            self.options.update(user_input)
+            return self.async_create_entry(
+                title=CONF_INTEGRATION_TITLE, data=self.options
+            )
 
-    return self.async_show_form(
-        step_id="webhooks",
-        data_schema=schema_with_defaults,
-        description_placeholders={
-            "webhook_url": webhook_url,
-            "status": status,
-        },
-    )
+        custom_url = self.options.get(
+            CONF_WEBHOOK_EXTERNAL_URL, DEFAULT_WEBHOOK_EXTERNAL_URL
+        )
 
+        try:
+            webhook_url = get_webhook_url(
+                self.hass, self.config_entry.entry_id, custom_url or None
+            )
+            status = "✅ Webhooks active and receiving data"  # Placeholder
+        except MerakiConnectionError as err:
+            webhook_url = f"⚠️ {err}"
+            status = "❌ Webhook URL not reachable"
 
-async def async_step_data_sync(
-    self,
-    user_input: dict[str, Any] | None = None,
-) -> ConfigFlowResult:
-    """Handle data sync settings."""
-    if user_input is not None:
-        self.options.update(user_input)
-        return self.async_create_entry(title=CONF_INTEGRATION_TITLE, data=self.options)
+        schema_with_defaults = self._populate_schema_defaults(
+            SCHEMA_WEBHOOKS,
+            self.options,
+        )
 
-    schema_with_defaults = self._populate_schema_defaults(
-        SCHEMA_DATA_SYNC,
-        self.options,
-    )
+        return self.async_show_form(
+            step_id="webhooks",
+            data_schema=schema_with_defaults,
+            description_placeholders={
+                "webhook_url": webhook_url,
+                "status": status,
+            },
+        )
 
-    return self.async_show_form(
-        step_id="data_sync",
-        data_schema=schema_with_defaults,
-    )
+    async def async_step_data_sync(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Handle data sync settings."""
+        if user_input is not None:
+            self.options.update(user_input)
+            return self.async_create_entry(
+                title=CONF_INTEGRATION_TITLE, data=self.options
+            )
+
+        schema_with_defaults = self._populate_schema_defaults(
+            SCHEMA_DATA_SYNC,
+            self.options,
+        )
+
+        return self.async_show_form(
+            step_id="data_sync",
+            data_schema=schema_with_defaults,
+        )

--- a/custom_components/meraki_ha/strings.json
+++ b/custom_components/meraki_ha/strings.json
@@ -105,6 +105,8 @@
         "menu_options": {
           "network_selection": "Network Selection",
           "polling": "Polling & Refresh",
+          "webhooks": "Webhooks",
+          "data_sync": "Data Sync",
           "camera": "Camera Settings",
           "mqtt": "MQTT Configuration",
           "scanning_api": "Scanning API",
@@ -143,6 +145,42 @@
           "device_scan_interval": "Polling interval for infrequently changing data like device inventory.",
           "client_scan_interval": "Polling interval for very frequently changing data like client information.",
           "ssid_scan_interval": "Polling interval for infrequently changing data like SSID configuration."
+        }
+      },
+      "webhooks": {
+        "title": "Webhook Settings",
+        "description": "Configure Meraki webhooks for real-time event notifications.\n\n**Webhook URL:** `{webhook_url}`\n\n**Status:** {status}",
+        "data": {
+          "enable_webhooks": "Enable Webhooks",
+          "webhook_external_url": "External URL (optional)",
+          "webhook_shared_secret": "Shared Secret",
+          "webhook_auto_register": "Auto-register Webhooks",
+          "webhook_alert_types": "Alert Types",
+          "webhook_polling_reduction": "Reduce Polling When Webhooks Active"
+        },
+        "data_description": {
+          "enable_webhooks": "Enable receiving real-time alerts from Meraki Dashboard via webhooks.",
+          "webhook_external_url": "Custom external URL for webhooks (e.g., https://ha.example.com). Leave empty to use Home Assistant's configured external URL.",
+          "webhook_shared_secret": "Shared secret for webhook verification. Meraki will include this in webhook requests.",
+          "webhook_auto_register": "Automatically register this webhook URL with Meraki Dashboard for selected networks.",
+          "webhook_alert_types": "Select which alert types to receive via webhooks.",
+          "webhook_polling_reduction": "Reduce polling frequency for data that can be received via webhooks."
+        }
+      },
+      "data_sync": {
+        "title": "Data Sync Settings",
+        "description": "Configure how data is synchronized between Home Assistant and Meraki.",
+        "data": {
+          "sync_names_to_meraki": "Sync Names to Meraki",
+          "sync_include_model": "Include Model in Synced Names",
+          "sync_include_version": "Include Version in Synced Names",
+          "sync_on_new_client": "Sync on New Client"
+        },
+        "data_description": {
+          "sync_names_to_meraki": "Push device name changes from Home Assistant back to Meraki Dashboard.",
+          "sync_include_model": "Include device model information when syncing names.",
+          "sync_include_version": "Include firmware version when syncing names.",
+          "sync_on_new_client": "Automatically sync when a new client is detected on the network."
         }
       },
       "display_preferences": {

--- a/custom_components/meraki_ha/translations/en.json
+++ b/custom_components/meraki_ha/translations/en.json
@@ -93,6 +93,8 @@
         "menu_options": {
           "network_selection": "Network Selection",
           "polling": "Polling & Refresh",
+          "webhooks": "Webhooks",
+          "data_sync": "Data Sync",
           "camera": "Camera Settings",
           "mqtt": "MQTT Configuration",
           "scanning_api": "Scanning API",
@@ -131,6 +133,42 @@
           "device_scan_interval": "Polling interval for infrequently changing data like device inventory.",
           "client_scan_interval": "Polling interval for very frequently changing data like client information.",
           "ssid_scan_interval": "Polling interval for infrequently changing data like SSID configuration."
+        }
+      },
+      "webhooks": {
+        "title": "Webhook Settings",
+        "description": "Configure Meraki webhooks for real-time event notifications.\n\n**Webhook URL:** `{webhook_url}`\n\n**Status:** {status}",
+        "data": {
+          "enable_webhooks": "Enable Webhooks",
+          "webhook_external_url": "External URL (optional)",
+          "webhook_shared_secret": "Shared Secret",
+          "webhook_auto_register": "Auto-register Webhooks",
+          "webhook_alert_types": "Alert Types",
+          "webhook_polling_reduction": "Reduce Polling When Webhooks Active"
+        },
+        "data_description": {
+          "enable_webhooks": "Enable receiving real-time alerts from Meraki Dashboard via webhooks.",
+          "webhook_external_url": "Custom external URL for webhooks (e.g., https://ha.example.com). Leave empty to use Home Assistant's configured external URL.",
+          "webhook_shared_secret": "Shared secret for webhook verification. Meraki will include this in webhook requests.",
+          "webhook_auto_register": "Automatically register this webhook URL with Meraki Dashboard for selected networks.",
+          "webhook_alert_types": "Select which alert types to receive via webhooks.",
+          "webhook_polling_reduction": "Reduce polling frequency for data that can be received via webhooks."
+        }
+      },
+      "data_sync": {
+        "title": "Data Sync Settings",
+        "description": "Configure how data is synchronized between Home Assistant and Meraki.",
+        "data": {
+          "sync_names_to_meraki": "Sync Names to Meraki",
+          "sync_include_model": "Include Model in Synced Names",
+          "sync_include_version": "Include Version in Synced Names",
+          "sync_on_new_client": "Sync on New Client"
+        },
+        "data_description": {
+          "sync_names_to_meraki": "Push device name changes from Home Assistant back to Meraki Dashboard.",
+          "sync_include_model": "Include device model information when syncing names.",
+          "sync_include_version": "Include firmware version when syncing names.",
+          "sync_on_new_client": "Automatically sync when a new client is detected on the network."
         }
       },
       "display_preferences": {


### PR DESCRIPTION
# Type of Change

-Bug fix (non-breaking change which fixes an issue)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

This PR addresses missing translations for the "Webhooks" and "Data Sync" options in the integration's configuration flow. It also corrects a structural bug where `async_step_webhooks` and `async_step_data_sync` methods were incorrectly defined outside the `MerakiOptionsFlowHandler` class.

## Motivation and Context

This change resolves Issue #118, improving the user experience by providing complete and accurate translations for all configuration options. It also fixes a code structure issue in the options flow handler.

## How Has This Been Tested?

All existing unit tests, linting, and type checks (`./run_checks.sh`) passed successfully after these changes.

## Screenshots (if appropriate)

N/A

## Types of changes

-Bug fix (non-breaking change which fixes an issue)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules

---
<a href="https://cursor.com/background-agent?bcId=bc-e68f90e7-afd3-48d4-accd-42a1333c9ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e68f90e7-afd3-48d4-accd-42a1333c9ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

