### PR TITLE
Home Assistant Meraki association

### DIFF
--- a/custom_components/meraki_ha/const.py
+++ b/custom_components/meraki_ha/const.py
@@ -85,6 +85,12 @@ DEFAULT_CAMERA_SNAPSHOT_INTERVAL: Final = 0
 CONF_CAMERA_ENTITY_MAPPINGS: Final = "camera_entity_mappings"
 """Configuration key for camera entity mappings (Meraki serial -> HA entity_id)."""
 
+CONF_MANUAL_CLIENT_ASSOCIATIONS: Final = "manual_client_associations"
+"""Configuration key for manual Meraki client to HA device associations."""
+
+DEFAULT_MANUAL_CLIENT_ASSOCIATIONS: Final[dict[str, str]] = {}
+"""Default empty dict for manual client associations (client_mac -> ha_device_id)."""
+
 CONF_MQTT_RELAY_DESTINATIONS: Final = "mqtt_relay_destinations"
 """Configuration key for MQTT relay destinations."""
 

--- a/custom_components/meraki_ha/options_flow.py
+++ b/custom_components/meraki_ha/options_flow.py
@@ -12,6 +12,7 @@ from .const import (
     CONF_ENABLE_MQTT,
     CONF_ENABLED_NETWORKS,
     CONF_INTEGRATION_TITLE,
+    CONF_MANUAL_CLIENT_ASSOCIATIONS,
     CONF_MQTT_RELAY_DESTINATIONS,
     DEFAULT_MQTT_PORT,
     DEFAULT_MQTT_RELAY_DESTINATIONS,
@@ -83,6 +84,7 @@ class MerakiOptionsFlowHandler(OptionsFlow):
             step_id="init",
             menu_options=[
                 "network_selection",
+                "device_association",
                 "polling",
                 "webhooks",
                 "data_sync",
@@ -181,6 +183,316 @@ class MerakiOptionsFlowHandler(OptionsFlow):
         return self.async_show_form(
             step_id="network_selection",
             data_schema=schema_with_defaults,
+        )
+
+    async def async_step_device_association(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Handle device association settings - main menu."""
+        from homeassistant.helpers import device_registry as dr
+
+        from .meraki_data_coordinator import MerakiDataCoordinator
+
+        if user_input is not None:
+            action = user_input.get("action", "save")
+
+            if action == "add":
+                return await self.async_step_select_client()
+            if action == "remove":
+                return await self.async_step_remove_association()
+
+            return self.async_create_entry(
+                title=CONF_INTEGRATION_TITLE, data=self.options
+            )
+
+        # Get current associations
+        current_associations: dict[str, str] = self.options.get(
+            CONF_MANUAL_CLIENT_ASSOCIATIONS, {}
+        )
+
+        # Build summary of current associations
+        association_summary = []
+        coordinator: MerakiDataCoordinator = self.hass.data[DOMAIN][
+            self.config_entry.entry_id
+        ]["coordinator"]
+        device_registry = dr.async_get(self.hass)
+
+        for client_mac, device_id in current_associations.items():
+            # Find client name
+            client_name = client_mac
+            if coordinator.data and coordinator.data.get("clients"):
+                for client in coordinator.data["clients"]:
+                    if client.get("mac") == client_mac:
+                        client_name = (
+                            client.get("description")
+                            or client.get("dhcpHostname")
+                            or client_mac
+                        )
+                        break
+
+            # Find device name
+            device = device_registry.async_get(device_id)
+            device_name = device.name if device else device_id
+
+            association_summary.append(f"• {client_name} → {device_name}")
+
+        summary_text = "\n".join(association_summary) if association_summary else "None"
+
+        actions = [
+            selector.SelectOptionDict(value="save", label="Save and Finish"),
+            selector.SelectOptionDict(value="add", label="Add new association"),
+        ]
+        if current_associations:
+            actions.append(
+                selector.SelectOptionDict(value="remove", label="Remove an association")
+            )
+
+        schema = vol.Schema(
+            {
+                vol.Optional("action", default="save"): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=actions,
+                        mode=selector.SelectSelectorMode.LIST,
+                    )
+                ),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="device_association",
+            data_schema=schema,
+            description_placeholders={
+                "association_count": str(len(current_associations)),
+                "associations": summary_text,
+            },
+        )
+
+    async def async_step_select_client(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Select a Meraki client to associate with an HA device."""
+        from .meraki_data_coordinator import MerakiDataCoordinator
+
+        if user_input is not None:
+            # Store selected client MAC and proceed to device selection
+            self._selected_client_mac = user_input.get("client")
+            return await self.async_step_select_device()
+
+        coordinator: MerakiDataCoordinator = self.hass.data[DOMAIN][
+            self.config_entry.entry_id
+        ]["coordinator"]
+
+        # Get current associations to filter out already-associated clients
+        current_associations: dict[str, str] = self.options.get(
+            CONF_MANUAL_CLIENT_ASSOCIATIONS, {}
+        )
+
+        # Build list of unassociated clients
+        client_options: list[selector.SelectOptionDict] = []
+        if coordinator.data and coordinator.data.get("clients"):
+            for client in coordinator.data["clients"]:
+                client_mac = client.get("mac")
+                if not client_mac or client_mac in current_associations:
+                    continue
+
+                # Generate friendly name
+                client_name = (
+                    client.get("description")
+                    or client.get("dhcpHostname")
+                    or client.get("ip")
+                    or client_mac
+                )
+                manufacturer = client.get("manufacturer", "")
+                if manufacturer:
+                    label = f"{client_name} ({manufacturer})"
+                else:
+                    label = client_name
+
+                client_options.append(
+                    selector.SelectOptionDict(value=client_mac, label=label)
+                )
+
+        if not client_options:
+            # No clients available
+            return self.async_show_form(
+                step_id="select_client",
+                data_schema=vol.Schema({}),
+                description_placeholders={
+                    "message": "No unassociated clients available."
+                },
+                errors={"base": "no_clients"},
+            )
+
+        # Sort by label
+        client_options.sort(key=lambda x: x["label"].lower())
+
+        schema = vol.Schema(
+            {
+                vol.Required("client"): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=client_options,
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="select_client",
+            data_schema=schema,
+        )
+
+    async def async_step_select_device(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Select an HA device to link the Meraki client to."""
+        from homeassistant.helpers import device_registry as dr
+
+        if user_input is not None:
+            # Save the association
+            device_id = user_input.get("device")
+            client_mac = getattr(self, "_selected_client_mac", None)
+
+            if client_mac and device_id:
+                associations = dict(
+                    self.options.get(CONF_MANUAL_CLIENT_ASSOCIATIONS, {})
+                )
+                associations[client_mac] = device_id
+                self.options[CONF_MANUAL_CLIENT_ASSOCIATIONS] = associations
+
+            # Clean up and return to main menu
+            self._selected_client_mac = None
+            return await self.async_step_device_association()
+
+        # Build list of HA devices (excluding Meraki client devices)
+        device_registry = dr.async_get(self.hass)
+        device_options: list[selector.SelectOptionDict] = []
+
+        for device in device_registry.devices.values():
+            # Skip Meraki client devices
+            if any(
+                DOMAIN in str(ident) and "client_" in str(ident)
+                for ident in device.identifiers
+            ):
+                continue
+
+            # Skip devices without a name
+            if not device.name:
+                continue
+
+            # Include manufacturer info if available
+            if device.manufacturer:
+                label = f"{device.name} ({device.manufacturer})"
+            else:
+                label = device.name
+
+            device_options.append(
+                selector.SelectOptionDict(value=device.id, label=label)
+            )
+
+        if not device_options:
+            return self.async_show_form(
+                step_id="select_device",
+                data_schema=vol.Schema({}),
+                errors={"base": "no_devices"},
+            )
+
+        # Sort by label
+        device_options.sort(key=lambda x: x["label"].lower())
+
+        schema = vol.Schema(
+            {
+                vol.Required("device"): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=device_options,
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="select_device",
+            data_schema=schema,
+        )
+
+    async def async_step_remove_association(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Remove an existing device association."""
+        from homeassistant.helpers import device_registry as dr
+
+        from .meraki_data_coordinator import MerakiDataCoordinator
+
+        if user_input is not None:
+            # Remove selected associations
+            selected_macs = user_input.get("associations", [])
+            if selected_macs:
+                associations = dict(
+                    self.options.get(CONF_MANUAL_CLIENT_ASSOCIATIONS, {})
+                )
+                for mac in selected_macs:
+                    associations.pop(mac, None)
+                self.options[CONF_MANUAL_CLIENT_ASSOCIATIONS] = associations
+
+            return await self.async_step_device_association()
+
+        # Build list of current associations
+        current_associations: dict[str, str] = self.options.get(
+            CONF_MANUAL_CLIENT_ASSOCIATIONS, {}
+        )
+
+        if not current_associations:
+            return await self.async_step_device_association()
+
+        coordinator: MerakiDataCoordinator = self.hass.data[DOMAIN][
+            self.config_entry.entry_id
+        ]["coordinator"]
+        device_registry = dr.async_get(self.hass)
+
+        association_options: list[selector.SelectOptionDict] = []
+        for client_mac, device_id in current_associations.items():
+            # Find client name
+            client_name = client_mac
+            if coordinator.data and coordinator.data.get("clients"):
+                for client in coordinator.data["clients"]:
+                    if client.get("mac") == client_mac:
+                        client_name = (
+                            client.get("description")
+                            or client.get("dhcpHostname")
+                            or client_mac
+                        )
+                        break
+
+            # Find device name
+            device = device_registry.async_get(device_id)
+            device_name = device.name if device else device_id
+
+            association_options.append(
+                selector.SelectOptionDict(
+                    value=client_mac, label=f"{client_name} → {device_name}"
+                )
+            )
+
+        schema = vol.Schema(
+            {
+                vol.Required("associations"): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=association_options,
+                        multiple=True,
+                        mode=selector.SelectSelectorMode.LIST,
+                    )
+                ),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="remove_association",
+            data_schema=schema,
         )
 
     async def async_step_polling(

--- a/custom_components/meraki_ha/schemas.py
+++ b/custom_components/meraki_ha/schemas.py
@@ -29,6 +29,7 @@ from .const import (
     CONF_LOG_LEVEL_SCANNING_API,
     CONF_LOG_LEVEL_SENSOR,
     CONF_LOG_LEVEL_SWITCH,
+    CONF_MANUAL_CLIENT_ASSOCIATIONS,
     CONF_MERAKI_API_KEY,
     CONF_MERAKI_ORG_ID,
     CONF_NETWORK_SCAN_INTERVAL,
@@ -559,5 +560,16 @@ SCHEMA_DATA_SYNC = vol.Schema(
             "sync_on_new_client",
             default=True,
         ): selector.BooleanSelector(),
+    }
+)
+
+# Section: Device Association Settings
+# Note: The actual selectors for client and device are built dynamically
+# in the options flow based on available clients and devices
+SCHEMA_DEVICE_ASSOCIATION = vol.Schema(
+    {
+        vol.Optional(
+            CONF_MANUAL_CLIENT_ASSOCIATIONS,
+        ): vol.Schema({str: str}),
     }
 )

--- a/custom_components/meraki_ha/sensor/client/base.py
+++ b/custom_components/meraki_ha/sensor/client/base.py
@@ -18,7 +18,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from ...const import DOMAIN
+from ...const import CONF_MANUAL_CLIENT_ASSOCIATIONS, DOMAIN
 from ...helpers.logging_helper import MerakiLoggers
 from ...meraki_data_coordinator import MerakiDataCoordinator
 
@@ -132,14 +132,79 @@ def _find_existing_device_by_ip(
     return None
 
 
+def _find_existing_device_by_manual_association(
+    hass: HomeAssistant,
+    mac_address: str,
+    config_entry: ConfigEntry | None = None,
+) -> dr.DeviceEntry | None:
+    """Find an existing Home Assistant device via manual association.
+
+    Checks the config entry options for manually configured client-to-device
+    associations.
+
+    Parameters
+    ----------
+    hass : HomeAssistant
+        The Home Assistant instance.
+    mac_address : str
+        The MAC address of the Meraki client.
+    config_entry : ConfigEntry | None
+        The config entry containing manual associations.
+
+    Returns
+    -------
+    dr.DeviceEntry | None
+        The matching device entry, or None if not found.
+
+    """
+    if not config_entry:
+        return None
+
+    # Get manual associations from config entry options
+    associations = config_entry.options.get(CONF_MANUAL_CLIENT_ASSOCIATIONS, {})
+    if not associations:
+        return None
+
+    # Normalize MAC address for comparison
+    normalized_mac = mac_address.lower().replace("-", ":")
+
+    # Check for manual association
+    device_id = associations.get(normalized_mac)
+    if not device_id:
+        # Also try with the original MAC format
+        device_id = associations.get(mac_address)
+
+    if not device_id:
+        return None
+
+    try:
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get(device_id)
+        if device:
+            _LOGGER.debug(
+                "Found manually associated device '%s' for MAC %s",
+                device.name,
+                mac_address,
+            )
+            return device
+    except (AttributeError, TypeError):
+        pass
+
+    return None
+
+
 def _find_existing_device(
     hass: HomeAssistant,
     mac_address: str,
     ip_address: str | None = None,
+    config_entry: ConfigEntry | None = None,
 ) -> dr.DeviceEntry | None:
-    """Find an existing Home Assistant device by MAC or IP address.
+    """Find an existing Home Assistant device by manual association, MAC, or IP.
 
-    Tries MAC first (more reliable), then falls back to IP matching.
+    Priority order:
+    1. Manual association (user-configured in options flow)
+    2. MAC address matching
+    3. IP address matching
 
     Parameters
     ----------
@@ -149,6 +214,8 @@ def _find_existing_device(
         The MAC address to search for.
     ip_address : str | None
         The IP address to search for (optional).
+    config_entry : ConfigEntry | None
+        The config entry containing manual associations (optional).
 
     Returns
     -------
@@ -156,10 +223,19 @@ def _find_existing_device(
         The matching device entry, or None if not found.
 
     """
+    # Try manual association first (user-configured)
+    device = _find_existing_device_by_manual_association(
+        hass, mac_address, config_entry
+    )
+    if device:
+        return device
+
+    # Try MAC matching
     device = _find_existing_device_by_mac(hass, mac_address)
     if device:
         return device
 
+    # Fall back to IP matching
     if ip_address:
         device = _find_existing_device_by_ip(hass, ip_address)
         if device:
@@ -209,9 +285,11 @@ class MerakiClientSensorBase(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = f"meraki_client_{self._client_mac}_{sensor_key}"
 
         # Check if this client matches an existing Home Assistant device
-        # Try MAC first, then IP address for devices without exposed MACs
+        # Priority: manual association > MAC matching > IP matching
         client_ip = client_data.get("ip")
-        existing_device = _find_existing_device(hass, self._client_mac, client_ip)
+        existing_device = _find_existing_device(
+            hass, self._client_mac, client_ip, config_entry
+        )
 
         if existing_device:
             # Link to the existing device

--- a/custom_components/meraki_ha/strings.json
+++ b/custom_components/meraki_ha/strings.json
@@ -104,6 +104,7 @@
         "description": "Select a category to configure:",
         "menu_options": {
           "network_selection": "Network Selection",
+          "device_association": "Device Association",
           "polling": "Polling & Refresh",
           "webhooks": "Webhooks",
           "data_sync": "Data Sync",
@@ -127,6 +128,46 @@
           "enabled_networks": "Select which networks to monitor. Leave empty for all networks.",
           "enable_device_tracker": "Enable tracking of clients connected to the network.",
           "enable_vlan_management": "Enable VLAN management features."
+        }
+      },
+      "device_association": {
+        "title": "Device Association",
+        "description": "Link Meraki network clients to existing Home Assistant devices.\n\nCurrent associations ({association_count}):\n{associations}",
+        "data": {
+          "action": "Action"
+        },
+        "data_description": {
+          "action": "Choose an action to manage device associations."
+        }
+      },
+      "select_client": {
+        "title": "Select Meraki Client",
+        "description": "Choose a Meraki network client to associate with a Home Assistant device.",
+        "data": {
+          "client": "Meraki Client"
+        },
+        "data_description": {
+          "client": "Select a client from your Meraki network."
+        }
+      },
+      "select_device": {
+        "title": "Select Home Assistant Device",
+        "description": "Choose a Home Assistant device to link with the selected Meraki client.",
+        "data": {
+          "device": "Home Assistant Device"
+        },
+        "data_description": {
+          "device": "Select a device from Home Assistant."
+        }
+      },
+      "remove_association": {
+        "title": "Remove Device Association",
+        "description": "Select associations to remove.",
+        "data": {
+          "associations": "Associations to Remove"
+        },
+        "data_description": {
+          "associations": "Select one or more associations to remove."
         }
       },
       "polling": {
@@ -345,7 +386,9 @@
     "error": {
       "host_required": "Broker hostname is required.",
       "name_required": "Destination name is required.",
-      "invalid_port": "Invalid port number. Must be between 1 and 65535."
+      "invalid_port": "Invalid port number. Must be between 1 and 65535.",
+      "no_clients": "No unassociated Meraki clients available. All clients are either already associated or no clients are connected.",
+      "no_devices": "No Home Assistant devices available to associate with."
     }
   },
   "entity": {

--- a/custom_components/meraki_ha/translations/en.json
+++ b/custom_components/meraki_ha/translations/en.json
@@ -92,6 +92,7 @@
         "description": "Select a category to configure:",
         "menu_options": {
           "network_selection": "Network Selection",
+          "device_association": "Device Association",
           "polling": "Polling & Refresh",
           "webhooks": "Webhooks",
           "data_sync": "Data Sync",
@@ -115,6 +116,46 @@
           "enabled_networks": "Select which networks to monitor. Leave empty for all networks.",
           "enable_device_tracker": "Enable tracking of clients connected to the network.",
           "enable_vlan_management": "Enable VLAN management features."
+        }
+      },
+      "device_association": {
+        "title": "Device Association",
+        "description": "Link Meraki network clients to existing Home Assistant devices.\n\nCurrent associations ({association_count}):\n{associations}",
+        "data": {
+          "action": "Action"
+        },
+        "data_description": {
+          "action": "Choose an action to manage device associations."
+        }
+      },
+      "select_client": {
+        "title": "Select Meraki Client",
+        "description": "Choose a Meraki network client to associate with a Home Assistant device.",
+        "data": {
+          "client": "Meraki Client"
+        },
+        "data_description": {
+          "client": "Select a client from your Meraki network."
+        }
+      },
+      "select_device": {
+        "title": "Select Home Assistant Device",
+        "description": "Choose a Home Assistant device to link with the selected Meraki client.",
+        "data": {
+          "device": "Home Assistant Device"
+        },
+        "data_description": {
+          "device": "Select a device from Home Assistant."
+        }
+      },
+      "remove_association": {
+        "title": "Remove Device Association",
+        "description": "Select associations to remove.",
+        "data": {
+          "associations": "Associations to Remove"
+        },
+        "data_description": {
+          "associations": "Select one or more associations to remove."
         }
       },
       "polling": {
@@ -299,7 +340,9 @@
     "error": {
       "host_required": "Broker hostname is required.",
       "name_required": "Destination name is required.",
-      "invalid_port": "Invalid port number. Must be between 1 and 65535."
+      "invalid_port": "Invalid port number. Must be between 1 and 65535.",
+      "no_clients": "No unassociated Meraki clients available. All clients are either already associated or no clients are connected.",
+      "no_devices": "No Home Assistant devices available to associate with."
     }
   },
   "entity": {

--- a/tests/test_device_association.py
+++ b/tests/test_device_association.py
@@ -1,0 +1,422 @@
+"""Tests for the device association feature.
+
+This module tests the manual device association functionality that allows
+users to link Meraki network clients to existing Home Assistant devices.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from custom_components.meraki_ha.const import (
+    CONF_MANUAL_CLIENT_ASSOCIATIONS,
+    DOMAIN,
+)
+from custom_components.meraki_ha.device_tracker import (
+    _find_existing_device,
+    _find_existing_device_by_manual_association,
+)
+from custom_components.meraki_ha.options_flow import MerakiOptionsFlowHandler
+
+# Sample client data for testing
+MOCK_CLIENT_DATA = {
+    "id": "client123",
+    "mac": "00:11:22:33:44:55",
+    "ip": "192.168.1.100",
+    "description": "Ring Doorbell",
+    "dhcpHostname": "ring-doorbell-1234",
+    "manufacturer": "Ring",
+    "networkId": "N_12345",
+}
+
+
+@pytest.fixture
+def mock_hass() -> MagicMock:
+    """Fixture for a mocked HomeAssistant instance."""
+    hass = MagicMock(spec=HomeAssistant)
+    return hass
+
+
+@pytest.fixture
+def mock_config_entry() -> MagicMock:
+    """Fixture for a mocked ConfigEntry with no manual associations."""
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = "test_entry_id"
+    entry.options = {}
+    return entry
+
+
+@pytest.fixture
+def mock_config_entry_with_associations() -> MagicMock:
+    """Fixture for a mocked ConfigEntry with manual associations."""
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = "test_entry_id"
+    entry.options = {
+        CONF_MANUAL_CLIENT_ASSOCIATIONS: {
+            "00:11:22:33:44:55": "device_id_123",
+            "aa:bb:cc:dd:ee:ff": "device_id_456",
+        }
+    }
+    return entry
+
+
+@pytest.fixture
+def mock_device_registry() -> MagicMock:
+    """Fixture for a mocked device registry."""
+    registry = MagicMock(spec=dr.DeviceRegistry)
+
+    # Create a mock device
+    mock_device = MagicMock()
+    mock_device.id = "device_id_123"
+    mock_device.name = "Ring Integration Device"
+    mock_device.manufacturer = "Ring"
+    mock_device.identifiers = {("ring", "123456")}
+    mock_device.connections = set()
+
+    registry.async_get.return_value = mock_device
+    registry.devices = {
+        "device_id_123": mock_device,
+    }
+
+    return registry
+
+
+class TestFindExistingDeviceByManualAssociation:
+    """Tests for _find_existing_device_by_manual_association function."""
+
+    def test_returns_none_when_no_config_entry(self, mock_hass: MagicMock) -> None:
+        """Test that None is returned when config_entry is None."""
+        result = _find_existing_device_by_manual_association(
+            mock_hass, "00:11:22:33:44:55", None
+        )
+        assert result is None
+
+    def test_returns_none_when_no_associations(
+        self, mock_hass: MagicMock, mock_config_entry: MagicMock
+    ) -> None:
+        """Test that None is returned when no associations are configured."""
+        result = _find_existing_device_by_manual_association(
+            mock_hass, "00:11:22:33:44:55", mock_config_entry
+        )
+        assert result is None
+
+    def test_returns_none_when_mac_not_in_associations(
+        self, mock_hass: MagicMock, mock_config_entry_with_associations: MagicMock
+    ) -> None:
+        """Test that None is returned when MAC is not in associations."""
+        result = _find_existing_device_by_manual_association(
+            mock_hass, "ff:ff:ff:ff:ff:ff", mock_config_entry_with_associations
+        )
+        assert result is None
+
+    @patch("custom_components.meraki_ha.device_tracker.dr.async_get")
+    def test_returns_device_when_association_exists(
+        self,
+        mock_dr_async_get: MagicMock,
+        mock_hass: MagicMock,
+        mock_config_entry_with_associations: MagicMock,
+        mock_device_registry: MagicMock,
+    ) -> None:
+        """Test that device is returned when association exists."""
+        mock_dr_async_get.return_value = mock_device_registry
+
+        result = _find_existing_device_by_manual_association(
+            mock_hass, "00:11:22:33:44:55", mock_config_entry_with_associations
+        )
+
+        assert result is not None
+        assert result.name == "Ring Integration Device"
+
+    @patch("custom_components.meraki_ha.device_tracker.dr.async_get")
+    def test_normalizes_mac_address(
+        self,
+        mock_dr_async_get: MagicMock,
+        mock_hass: MagicMock,
+        mock_config_entry_with_associations: MagicMock,
+        mock_device_registry: MagicMock,
+    ) -> None:
+        """Test that MAC address is normalized for comparison."""
+        mock_dr_async_get.return_value = mock_device_registry
+
+        # Test with uppercase MAC
+        result = _find_existing_device_by_manual_association(
+            mock_hass, "00:11:22:33:44:55", mock_config_entry_with_associations
+        )
+        assert result is not None
+
+        # Test with dash-separated MAC
+        result = _find_existing_device_by_manual_association(
+            mock_hass, "00-11-22-33-44-55", mock_config_entry_with_associations
+        )
+        assert result is not None
+
+
+class TestFindExistingDevice:
+    """Tests for _find_existing_device function with manual associations."""
+
+    @patch(
+        "custom_components.meraki_ha.device_tracker._find_existing_device_by_manual_association"
+    )
+    @patch("custom_components.meraki_ha.device_tracker._find_existing_device_by_mac")
+    @patch("custom_components.meraki_ha.device_tracker._find_existing_device_by_ip")
+    def test_manual_association_has_priority(
+        self,
+        mock_find_by_ip: MagicMock,
+        mock_find_by_mac: MagicMock,
+        mock_find_by_manual: MagicMock,
+        mock_hass: MagicMock,
+        mock_config_entry_with_associations: MagicMock,
+    ) -> None:
+        """Test that manual association takes priority over MAC/IP matching."""
+        # Set up mock to return a device for manual association
+        mock_manual_device = MagicMock()
+        mock_manual_device.name = "Manual Association Device"
+        mock_find_by_manual.return_value = mock_manual_device
+
+        # Set up mocks for MAC and IP to return different devices
+        mock_mac_device = MagicMock()
+        mock_mac_device.name = "MAC Match Device"
+        mock_find_by_mac.return_value = mock_mac_device
+
+        mock_ip_device = MagicMock()
+        mock_ip_device.name = "IP Match Device"
+        mock_find_by_ip.return_value = mock_ip_device
+
+        result = _find_existing_device(
+            mock_hass,
+            "00:11:22:33:44:55",
+            "192.168.1.100",
+            mock_config_entry_with_associations,
+        )
+
+        assert result == mock_manual_device
+        mock_find_by_manual.assert_called_once()
+        # MAC and IP should not be called when manual association is found
+        mock_find_by_mac.assert_not_called()
+        mock_find_by_ip.assert_not_called()
+
+    @patch(
+        "custom_components.meraki_ha.device_tracker._find_existing_device_by_manual_association"
+    )
+    @patch("custom_components.meraki_ha.device_tracker._find_existing_device_by_mac")
+    @patch("custom_components.meraki_ha.device_tracker._find_existing_device_by_ip")
+    def test_falls_back_to_mac_when_no_manual_association(
+        self,
+        mock_find_by_ip: MagicMock,
+        mock_find_by_mac: MagicMock,
+        mock_find_by_manual: MagicMock,
+        mock_hass: MagicMock,
+        mock_config_entry: MagicMock,
+    ) -> None:
+        """Test that MAC matching is used when no manual association exists."""
+        mock_find_by_manual.return_value = None
+
+        mock_mac_device = MagicMock()
+        mock_mac_device.name = "MAC Match Device"
+        mock_find_by_mac.return_value = mock_mac_device
+
+        result = _find_existing_device(
+            mock_hass, "00:11:22:33:44:55", "192.168.1.100", mock_config_entry
+        )
+
+        assert result == mock_mac_device
+        mock_find_by_manual.assert_called_once()
+        mock_find_by_mac.assert_called_once()
+        mock_find_by_ip.assert_not_called()
+
+
+class TestDeviceAssociationOptionsFlow:
+    """Tests for the device association options flow step."""
+
+    def _create_options_flow_handler(
+        self,
+        options: dict[str, Any] | None = None,
+        clients: list[dict[str, Any]] | None = None,
+    ) -> MerakiOptionsFlowHandler:
+        """Create an options flow handler with mocked dependencies."""
+        if options is None:
+            options = {}
+        if clients is None:
+            clients = [MOCK_CLIENT_DATA]
+
+        handler = MerakiOptionsFlowHandler()
+
+        # Create mock config entry
+        mock_entry = MagicMock()
+        mock_entry.entry_id = "test_entry_id"
+        mock_entry.options = options
+
+        # Set up hass mock
+        hass = MagicMock()
+        mock_coordinator = MagicMock()
+        mock_coordinator.data = {
+            "clients": clients,
+            "networks": [],
+        }
+        hass.data = {
+            DOMAIN: {
+                "test_entry_id": {
+                    "coordinator": mock_coordinator,
+                }
+            }
+        }
+        hass.config_entries.async_get_known_entry.return_value = mock_entry
+
+        # Mock device registry
+        mock_device = MagicMock()
+        mock_device.id = "device_id_123"
+        mock_device.name = "Ring Doorbell"
+        mock_device.manufacturer = "Ring"
+        mock_device.identifiers = {("ring", "123456")}
+
+        mock_device_registry = MagicMock()
+        mock_device_registry.devices = MagicMock()
+        mock_device_registry.devices.values.return_value = [mock_device]
+        mock_device_registry.async_get.return_value = mock_device
+
+        handler.hass = hass
+        handler._options = options
+        handler._options_initialized = True
+
+        # Set the handler property (this is what the framework sets - it's the entry ID)
+        handler.handler = "test_entry_id"
+
+        # Mock the config_entry property to return our mock
+        handler._config_entry = mock_entry  # type: ignore[attr-defined]
+
+        return handler
+
+    @pytest.mark.asyncio
+    async def test_device_association_menu_shows_add_option(self) -> None:
+        """Test that device association menu shows add option."""
+        handler = self._create_options_flow_handler()
+
+        with patch("homeassistant.helpers.device_registry.async_get") as mock_dr:
+            mock_device_registry = MagicMock()
+            mock_device_registry.devices = MagicMock()
+            mock_device_registry.devices.values.return_value = []
+            mock_device_registry.async_get.return_value = None
+            mock_dr.return_value = mock_device_registry
+
+            result = await handler.async_step_device_association()
+
+            assert result["type"] == "form"
+            assert result["step_id"] == "device_association"
+            assert result["data_schema"] is not None
+            assert "action" in result["data_schema"].schema
+
+    @pytest.mark.asyncio
+    async def test_device_association_shows_remove_when_associations_exist(
+        self,
+    ) -> None:
+        """Test that remove option appears when associations exist."""
+        options = {
+            CONF_MANUAL_CLIENT_ASSOCIATIONS: {
+                "00:11:22:33:44:55": "device_id_123",
+            }
+        }
+        handler = self._create_options_flow_handler(options=options)
+
+        with patch("homeassistant.helpers.device_registry.async_get") as mock_dr:
+            mock_device = MagicMock()
+            mock_device.id = "device_id_123"
+            mock_device.name = "Ring Doorbell"
+
+            mock_device_registry = MagicMock()
+            mock_device_registry.async_get.return_value = mock_device
+            mock_dr.return_value = mock_device_registry
+
+            result = await handler.async_step_device_association()
+
+            assert result["type"] == "form"
+            placeholders = result.get("description_placeholders", {})
+            assert placeholders is not None
+            assert "1" in str(placeholders.get("association_count", ""))
+
+    @pytest.mark.asyncio
+    async def test_select_client_shows_available_clients(self) -> None:
+        """Test that select_client step shows available clients."""
+        handler = self._create_options_flow_handler()
+
+        result = await handler.async_step_select_client()
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "select_client"
+        assert result["data_schema"] is not None
+        assert "client" in result["data_schema"].schema
+
+    @pytest.mark.asyncio
+    async def test_select_client_stores_selection_and_proceeds(self) -> None:
+        """Test that selecting a client proceeds to device selection."""
+        handler = self._create_options_flow_handler()
+
+        with patch.object(handler, "async_step_select_device") as mock_select_device:
+            mock_select_device.return_value = {"type": "form"}
+
+            await handler.async_step_select_client(
+                user_input={"client": "00:11:22:33:44:55"}
+            )
+
+            assert handler._selected_client_mac == "00:11:22:33:44:55"
+            mock_select_device.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_select_device_saves_association(self) -> None:
+        """Test that selecting a device saves the association."""
+        handler = self._create_options_flow_handler()
+        handler._selected_client_mac = "00:11:22:33:44:55"
+
+        with patch("homeassistant.helpers.device_registry.async_get") as mock_dr:
+            mock_device = MagicMock()
+            mock_device.id = "device_id_123"
+            mock_device.name = "Ring Doorbell"
+            mock_device.manufacturer = "Ring"
+            mock_device.identifiers = {("ring", "123456")}
+
+            mock_device_registry = MagicMock()
+            mock_device_registry.devices = MagicMock()
+            mock_device_registry.devices.values.return_value = [mock_device]
+            mock_device_registry.async_get.return_value = mock_device
+            mock_dr.return_value = mock_device_registry
+
+            await handler.async_step_select_device(
+                user_input={"device": "device_id_123"}
+            )
+
+            # Verify the association was saved
+            associations = handler.options.get(CONF_MANUAL_CLIENT_ASSOCIATIONS, {})
+            assert "00:11:22:33:44:55" in associations
+            assert associations["00:11:22:33:44:55"] == "device_id_123"
+
+    @pytest.mark.asyncio
+    async def test_remove_association_deletes_association(self) -> None:
+        """Test that remove_association step deletes selected associations."""
+        options = {
+            CONF_MANUAL_CLIENT_ASSOCIATIONS: {
+                "00:11:22:33:44:55": "device_id_123",
+                "aa:bb:cc:dd:ee:ff": "device_id_456",
+            }
+        }
+        handler = self._create_options_flow_handler(options=options)
+
+        with patch("homeassistant.helpers.device_registry.async_get") as mock_dr:
+            mock_device = MagicMock()
+            mock_device.name = "Test Device"
+            mock_device_registry = MagicMock()
+            mock_device_registry.async_get.return_value = mock_device
+            mock_dr.return_value = mock_device_registry
+
+            await handler.async_step_remove_association(
+                user_input={"associations": ["00:11:22:33:44:55"]}
+            )
+
+            # Verify the association was removed
+            associations = handler.options.get(CONF_MANUAL_CLIENT_ASSOCIATIONS, {})
+            assert "00:11:22:33:44:55" not in associations
+            assert "aa:bb:cc:dd:ee:ff" in associations


### PR DESCRIPTION
Implement manual association between Meraki clients and Home Assistant devices to resolve issues with automatic device matching.

---
<a href="https://cursor.com/background-agent?bcId=bc-2cb9801e-09f9-40df-b1b7-4fcb970bb27d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2cb9801e-09f9-40df-b1b7-4fcb970bb27d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

