### PR TITLE
Lovelace phase quality

### DIFF
--- a/custom_components/meraki_ha/api/websocket.py
+++ b/custom_components/meraki_ha/api/websocket.py
@@ -2,24 +2,36 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
 
-from ..const import DOMAIN
+from ..const import DATA_CLIENT, DOMAIN
+from ..helpers.logging_helper import MerakiLoggers
 from ..meraki_data_coordinator import MerakiDataCoordinator
+
+_LOGGER = MerakiLoggers.API
 
 
 def async_setup_websocket_api(hass: HomeAssistant) -> None:
     """Set up the WebSocket API."""
+    # Read endpoints
     websocket_api.async_register_command(hass, ws_get_overview)
+    websocket_api.async_register_command(hass, ws_get_networks)
     websocket_api.async_register_command(hass, ws_get_device)
+    websocket_api.async_register_command(hass, ws_get_device_clients)
+    websocket_api.async_register_command(hass, ws_get_client)
     websocket_api.async_register_command(hass, ws_get_clients)
     websocket_api.async_register_command(hass, ws_get_ssids)
     websocket_api.async_register_command(hass, ws_get_switch_ports)
     websocket_api.async_register_command(hass, ws_subscribe_updates)
+    # Action endpoints
     websocket_api.async_register_command(hass, ws_block_client)
     websocket_api.async_register_command(hass, ws_unblock_client)
+    websocket_api.async_register_command(hass, ws_set_switch_port)
+    websocket_api.async_register_command(hass, ws_set_client_policy)
 
 
 @websocket_api.websocket_command(
@@ -230,3 +242,188 @@ async def ws_unblock_client(
         return
 
     connection.send_result(msg["id"], {"status": "success", "mac": msg["mac"]})
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "meraki/get_networks",
+        vol.Required("config_entry_id"): str,
+    }
+)
+@websocket_api.async_response
+async def ws_get_networks(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
+) -> None:
+    """Get list of networks."""
+    entry_id = msg["config_entry_id"]
+    if entry_id not in hass.data[DOMAIN]:
+        connection.send_error(msg["id"], "not_found", "Config entry not found.")
+        return
+
+    coordinator: MerakiDataCoordinator = hass.data[DOMAIN][entry_id]["coordinator"]
+    networks = coordinator.data.get("networks", [])
+    connection.send_result(msg["id"], networks)
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "meraki/get_client",
+        vol.Required("config_entry_id"): str,
+        vol.Required("mac"): str,
+    }
+)
+@websocket_api.async_response
+async def ws_get_client(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
+) -> None:
+    """Get single client details by MAC address."""
+    entry_id = msg["config_entry_id"]
+    if entry_id not in hass.data[DOMAIN]:
+        connection.send_error(msg["id"], "not_found", "Config entry not found.")
+        return
+
+    coordinator: MerakiDataCoordinator = hass.data[DOMAIN][entry_id]["coordinator"]
+    mac = msg["mac"].lower()
+    client = next(
+        (
+            c
+            for c in coordinator.data.get("clients", [])
+            if c.get("mac", "").lower() == mac
+        ),
+        None,
+    )
+    if client:
+        connection.send_result(msg["id"], client)
+    else:
+        connection.send_error(msg["id"], "not_found", "Client not found.")
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "meraki/get_device_clients",
+        vol.Required("config_entry_id"): str,
+        vol.Required("serial"): str,
+    }
+)
+@websocket_api.async_response
+async def ws_get_device_clients(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
+) -> None:
+    """Get clients connected to a specific device."""
+    entry_id = msg["config_entry_id"]
+    if entry_id not in hass.data[DOMAIN]:
+        connection.send_error(msg["id"], "not_found", "Config entry not found.")
+        return
+
+    coordinator: MerakiDataCoordinator = hass.data[DOMAIN][entry_id]["coordinator"]
+    serial = msg["serial"]
+
+    # Filter clients by the device they're connected to
+    # Clients have a 'recentDeviceSerial' or 'switchport' field indicating connection
+    device_clients = [
+        c
+        for c in coordinator.data.get("clients", [])
+        if c.get("recentDeviceSerial") == serial
+        or c.get("recentDeviceMac") == serial  # Some APIs use MAC
+    ]
+    connection.send_result(msg["id"], device_clients)
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "meraki/set_switch_port",
+        vol.Required("config_entry_id"): str,
+        vol.Required("serial"): str,
+        vol.Required("port_id"): str,
+        vol.Required("enabled"): bool,
+    }
+)
+@websocket_api.async_response
+async def ws_set_switch_port(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
+) -> None:
+    """Enable or disable a switch port."""
+    entry_id = msg["config_entry_id"]
+    if entry_id not in hass.data[DOMAIN]:
+        connection.send_error(msg["id"], "not_found", "Config entry not found.")
+        return
+
+    api_client = hass.data[DOMAIN][entry_id].get(DATA_CLIENT)
+    if not api_client or not api_client.dashboard:
+        connection.send_error(msg["id"], "api_error", "API client not available.")
+        return
+
+    serial = msg["serial"]
+    port_id = msg["port_id"]
+    enabled = msg["enabled"]
+
+    try:
+        result = await api_client.dashboard.switch.updateDeviceSwitchPort(
+            serial=serial,
+            portId=port_id,
+            enabled=enabled,
+        )
+        _LOGGER.info("Switch port %s on %s set to enabled=%s", port_id, serial, enabled)
+        connection.send_result(msg["id"], _sanitize_result(result))
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.error("Failed to update switch port: %s", err)
+        connection.send_error(msg["id"], "api_error", str(err))
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "meraki/set_client_policy",
+        vol.Required("config_entry_id"): str,
+        vol.Required("network_id"): str,
+        vol.Required("client_id"): str,
+        vol.Required("policy"): str,
+        vol.Optional("group_policy_id"): str,
+    }
+)
+@websocket_api.async_response
+async def ws_set_client_policy(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
+) -> None:
+    """Set policy for a client (Normal, Allowed, Blocked, or Group policy)."""
+    entry_id = msg["config_entry_id"]
+    if entry_id not in hass.data[DOMAIN]:
+        connection.send_error(msg["id"], "not_found", "Config entry not found.")
+        return
+
+    api_client = hass.data[DOMAIN][entry_id].get(DATA_CLIENT)
+    if not api_client or not api_client.dashboard:
+        connection.send_error(msg["id"], "api_error", "API client not available.")
+        return
+
+    network_id = msg["network_id"]
+    client_id = msg["client_id"]
+    policy = msg["policy"]
+    group_policy_id = msg.get("group_policy_id")
+
+    try:
+        kwargs: dict[str, Any] = {"devicePolicy": policy}
+        if group_policy_id and policy == "Group policy":
+            kwargs["groupPolicyId"] = group_policy_id
+
+        result = await api_client.dashboard.networks.updateNetworkClientPolicy(
+            networkId=network_id,
+            clientId=client_id,
+            **kwargs,
+        )
+        _LOGGER.info(
+            "Client %s policy set to %s (group: %s)",
+            client_id,
+            policy,
+            group_policy_id,
+        )
+        connection.send_result(msg["id"], _sanitize_result(result))
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.error("Failed to update client policy: %s", err)
+        connection.send_error(msg["id"], "api_error", str(err))
+
+
+def _sanitize_result(result: Any) -> dict[str, Any]:
+    """Sanitize API result for JSON serialization."""
+    if isinstance(result, dict):
+        return result
+    return {"result": str(result)}

--- a/tests/api/test_websocket_api.py
+++ b/tests/api/test_websocket_api.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.core import HomeAssistant
 
 from custom_components.meraki_ha.api.websocket import async_setup_websocket_api
-from custom_components.meraki_ha.const import DOMAIN
+from custom_components.meraki_ha.const import DATA_CLIENT, DOMAIN
 
 CONFIG_ENTRY_ID = "test_entry_id"
 
@@ -27,14 +27,38 @@ def mock_coordinator():
     coordinator.last_update_success = True
     coordinator.data = {
         "devices": [{"serial": "123", "name": "Test Device"}],
-        "clients": [{"mac": "aa:bb:cc:dd:ee:ff", "description": "Test Client"}],
+        "clients": [
+            {
+                "mac": "aa:bb:cc:dd:ee:ff",
+                "description": "Test Client",
+                "recentDeviceSerial": "123",
+                "networkId": "N_123",
+            }
+        ],
         "ssids": [{"number": 0, "name": "Test SSID"}],
+        "networks": [{"id": "N_123", "name": "Test Network"}],
     }
     return coordinator
 
 
 @pytest.fixture
-def mock_hass(hass: HomeAssistant, mock_coordinator):
+def mock_api_client():
+    """Mock the MerakiAPIClient."""
+    api_client = MagicMock()
+    api_client.dashboard = MagicMock()
+    api_client.dashboard.switch = MagicMock()
+    api_client.dashboard.switch.updateDeviceSwitchPort = AsyncMock(
+        return_value={"portId": "1", "enabled": True}
+    )
+    api_client.dashboard.networks = MagicMock()
+    api_client.dashboard.networks.updateNetworkClientPolicy = AsyncMock(
+        return_value={"mac": "aa:bb:cc:dd:ee:ff", "devicePolicy": "Normal"}
+    )
+    return api_client
+
+
+@pytest.fixture
+def mock_hass(hass: HomeAssistant, mock_coordinator, mock_api_client):
     """Mock the Home Assistant instance."""
     hass.data[DOMAIN] = {
         CONFIG_ENTRY_ID: {
@@ -42,6 +66,7 @@ def mock_hass(hass: HomeAssistant, mock_coordinator):
             "switch_port_coordinator": AsyncMock(
                 last_update_success=True, data=[{"portId": "1"}]
             ),
+            DATA_CLIENT: mock_api_client,
         }
     }
     return hass
@@ -183,3 +208,253 @@ async def test_ws_command_coordinator_not_ready(hass_ws_client, mock_hass):
     msg = await client.receive_json()
     assert not msg["success"]
     assert msg["error"]["code"] == "coordinator_not_ready"
+
+
+async def test_ws_get_networks(hass_ws_client, mock_hass):
+    """Test get_networks websocket command."""
+    client = await hass_ws_client(mock_hass)
+    await client.send_json(
+        {"id": 11, "type": "meraki/get_networks", "config_entry_id": CONFIG_ENTRY_ID}
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"][0]["id"] == "N_123"
+    assert msg["result"][0]["name"] == "Test Network"
+
+
+async def test_ws_get_client(hass_ws_client, mock_hass):
+    """Test get_client websocket command."""
+    client = await hass_ws_client(mock_hass)
+    await client.send_json(
+        {
+            "id": 12,
+            "type": "meraki/get_client",
+            "config_entry_id": CONFIG_ENTRY_ID,
+            "mac": "aa:bb:cc:dd:ee:ff",
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"]["mac"] == "aa:bb:cc:dd:ee:ff"
+    assert msg["result"]["description"] == "Test Client"
+
+
+async def test_ws_get_client_not_found(hass_ws_client, mock_hass):
+    """Test get_client websocket command with unknown MAC."""
+    client = await hass_ws_client(mock_hass)
+    await client.send_json(
+        {
+            "id": 13,
+            "type": "meraki/get_client",
+            "config_entry_id": CONFIG_ENTRY_ID,
+            "mac": "11:22:33:44:55:66",
+        }
+    )
+    msg = await client.receive_json()
+    assert not msg["success"]
+    assert msg["error"]["code"] == "not_found"
+
+
+async def test_ws_get_client_case_insensitive(hass_ws_client, mock_hass):
+    """Test get_client is case-insensitive for MAC address."""
+    client = await hass_ws_client(mock_hass)
+    await client.send_json(
+        {
+            "id": 14,
+            "type": "meraki/get_client",
+            "config_entry_id": CONFIG_ENTRY_ID,
+            "mac": "AA:BB:CC:DD:EE:FF",  # Uppercase
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"]["mac"] == "aa:bb:cc:dd:ee:ff"
+
+
+async def test_ws_get_device_clients(hass_ws_client, mock_hass):
+    """Test get_device_clients websocket command."""
+    client = await hass_ws_client(mock_hass)
+    await client.send_json(
+        {
+            "id": 15,
+            "type": "meraki/get_device_clients",
+            "config_entry_id": CONFIG_ENTRY_ID,
+            "serial": "123",
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert len(msg["result"]) == 1
+    assert msg["result"][0]["mac"] == "aa:bb:cc:dd:ee:ff"
+
+
+async def test_ws_get_device_clients_empty(hass_ws_client, mock_hass):
+    """Test get_device_clients with no matching clients."""
+    client = await hass_ws_client(mock_hass)
+    await client.send_json(
+        {
+            "id": 16,
+            "type": "meraki/get_device_clients",
+            "config_entry_id": CONFIG_ENTRY_ID,
+            "serial": "999",  # No clients connected
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert len(msg["result"]) == 0
+
+
+async def test_ws_set_switch_port(hass_ws_client, mock_hass):
+    """Test set_switch_port websocket command."""
+    client = await hass_ws_client(mock_hass)
+    await client.send_json(
+        {
+            "id": 17,
+            "type": "meraki/set_switch_port",
+            "config_entry_id": CONFIG_ENTRY_ID,
+            "serial": "123",
+            "port_id": "1",
+            "enabled": True,
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"]["enabled"] is True
+
+    # Verify API was called correctly
+    mock_hass.data[DOMAIN][CONFIG_ENTRY_ID][
+        DATA_CLIENT
+    ].dashboard.switch.updateDeviceSwitchPort.assert_called_once_with(
+        serial="123",
+        portId="1",
+        enabled=True,
+    )
+
+
+async def test_ws_set_switch_port_disable(hass_ws_client, mock_hass):
+    """Test set_switch_port to disable a port."""
+    mock_hass.data[DOMAIN][CONFIG_ENTRY_ID][
+        DATA_CLIENT
+    ].dashboard.switch.updateDeviceSwitchPort = AsyncMock(
+        return_value={"portId": "2", "enabled": False}
+    )
+
+    client = await hass_ws_client(mock_hass)
+    await client.send_json(
+        {
+            "id": 18,
+            "type": "meraki/set_switch_port",
+            "config_entry_id": CONFIG_ENTRY_ID,
+            "serial": "123",
+            "port_id": "2",
+            "enabled": False,
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"]["enabled"] is False
+
+
+async def test_ws_set_client_policy(hass_ws_client, mock_hass):
+    """Test set_client_policy websocket command."""
+    client = await hass_ws_client(mock_hass)
+    await client.send_json(
+        {
+            "id": 19,
+            "type": "meraki/set_client_policy",
+            "config_entry_id": CONFIG_ENTRY_ID,
+            "network_id": "N_123",
+            "client_id": "aa:bb:cc:dd:ee:ff",
+            "policy": "Normal",
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"]["devicePolicy"] == "Normal"
+
+    # Verify API was called correctly
+    mock_hass.data[DOMAIN][CONFIG_ENTRY_ID][
+        DATA_CLIENT
+    ].dashboard.networks.updateNetworkClientPolicy.assert_called_once_with(
+        networkId="N_123",
+        clientId="aa:bb:cc:dd:ee:ff",
+        devicePolicy="Normal",
+    )
+
+
+async def test_ws_set_client_policy_with_group(hass_ws_client, mock_hass):
+    """Test set_client_policy with group policy."""
+    mock_hass.data[DOMAIN][CONFIG_ENTRY_ID][
+        DATA_CLIENT
+    ].dashboard.networks.updateNetworkClientPolicy = AsyncMock(
+        return_value={
+            "mac": "aa:bb:cc:dd:ee:ff",
+            "devicePolicy": "Group policy",
+            "groupPolicyId": "101",
+        }
+    )
+
+    client = await hass_ws_client(mock_hass)
+    await client.send_json(
+        {
+            "id": 20,
+            "type": "meraki/set_client_policy",
+            "config_entry_id": CONFIG_ENTRY_ID,
+            "network_id": "N_123",
+            "client_id": "aa:bb:cc:dd:ee:ff",
+            "policy": "Group policy",
+            "group_policy_id": "101",
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"]["devicePolicy"] == "Group policy"
+    assert msg["result"]["groupPolicyId"] == "101"
+
+
+async def test_ws_set_switch_port_api_error(hass_ws_client, mock_hass):
+    """Test set_switch_port when API fails."""
+    mock_hass.data[DOMAIN][CONFIG_ENTRY_ID][
+        DATA_CLIENT
+    ].dashboard.switch.updateDeviceSwitchPort = AsyncMock(
+        side_effect=Exception("API connection failed")
+    )
+
+    client = await hass_ws_client(mock_hass)
+    await client.send_json(
+        {
+            "id": 21,
+            "type": "meraki/set_switch_port",
+            "config_entry_id": CONFIG_ENTRY_ID,
+            "serial": "123",
+            "port_id": "1",
+            "enabled": True,
+        }
+    )
+    msg = await client.receive_json()
+    assert not msg["success"]
+    assert msg["error"]["code"] == "api_error"
+
+
+async def test_ws_set_client_policy_api_error(hass_ws_client, mock_hass):
+    """Test set_client_policy when API fails."""
+    mock_hass.data[DOMAIN][CONFIG_ENTRY_ID][
+        DATA_CLIENT
+    ].dashboard.networks.updateNetworkClientPolicy = AsyncMock(
+        side_effect=Exception("Network error")
+    )
+
+    client = await hass_ws_client(mock_hass)
+    await client.send_json(
+        {
+            "id": 22,
+            "type": "meraki/set_client_policy",
+            "config_entry_id": CONFIG_ENTRY_ID,
+            "network_id": "N_123",
+            "client_id": "aa:bb:cc:dd:ee:ff",
+            "policy": "Blocked",
+        }
+    )
+    msg = await client.receive_json()
+    assert not msg["success"]
+    assert msg["error"]["code"] == "api_error"


### PR DESCRIPTION
# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

This PR expands the WebSocket API by adding 5 new endpoints to enhance Lovelace card functionality.

## Motivation and Context

The existing WebSocket API was missing several key endpoints necessary for a complete Lovelace UI experience, particularly for detailed client and device information, and for performing common network actions. These additions address the need for:
*   Retrieving a list of networks.
*   Getting specific client details and clients connected to a device.
*   Enabling/disabling switch ports.
*   Applying group policies to clients.

These new endpoints provide more granular control and data access, making the integration more robust for custom Lovelace dashboards.

## How Has This Been Tested?

-   Added 12 new unit tests for the newly introduced WebSocket endpoints.
-   All existing unit tests pass.
-   `./run_checks.sh` passed successfully (ruff, mypy, bandit, pytest).

## Screenshots (if appropriate)

N/A

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules

---
<a href="https://cursor.com/background-agent?bcId=bc-51cb4f69-de69-435a-b8a8-ceb71a354ddb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-51cb4f69-de69-435a-b8a8-ceb71a354ddb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

---
Closes #1